### PR TITLE
Configura myst_parser

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,9 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = [
+    "myst_parser",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
A instalação do `myst_parser` foi feita, porém faltou configurá-lo. Para que possamos usar markdown no manual, basta adicionar `myst_parser` como extensão.

