### PR TITLE
Adiciona aviso em relação as regras e prazos para Assembleias da APyB

### DIFF
--- a/source/organizacao/index.md
+++ b/source/organizacao/index.md
@@ -115,11 +115,17 @@ O time tecnico é de longe talvez o que mais pessoas vão querer participar, poi
 ### Time de Conteúdo
 
 Responsável por gerenciar a grade de atividades oficiais do evento como palestras, tutoriais, assembleias, keynotes.
+
 - Criação e configuração do evento na ferramenta de submissão de atividades (por padrão utilizamos a ferramenta pretalx)
 - Criação do formulário de submissão de atividades
 - Avaliação de atividades para definir quais entram na grade
 - Definição de estratégias de seleção de keynotes (votação garantia que ja não tenha sido, alem de estrategia de marketing encima do keynote)
-  
+
+> É comum (apesar de não obrigatório) que a Assembleia Geral da APyB ocorra presencialmente
+> durante a Python Brasil. A convocação de Assembleias possui regras definidas no
+> [Estatuto](https://github.com/apyb/estatuto/) da Associação para que tenham validade
+> legal. Fiquem atentos, especialmente em relação a **prazos de divulgação** às pessoas
+> associadas para evitar problemas que impeçam sua realização.
 
 ## Definição do evento
 


### PR DESCRIPTION
Dado que existem regrtas e prazos rígidos definidos no Estatuto da APyB, e que as Assembleias Gerais da APyB são comumente realizadas durante a Python Brasil, ter um aviso direcionado ao Time de Conteúdo para que eles não se esqueçam de tomar precauções com isso pode evitar problemas no futuro.

![aviso](https://github.com/user-attachments/assets/630bca0e-fce1-45a5-b529-d1628e947528)
